### PR TITLE
Fix `help` bug to print all of the commands

### DIFF
--- a/lithium.js
+++ b/lithium.js
@@ -162,7 +162,7 @@ module.exports = () => {
 		 */
 		import: function (fileCommands) {
 			// Adds the given commands to app's internal command list
-			commands.push(...fileCommands)
+			commands.push(...fileCommands.filter(({ command }) => command !== "help"))
 		},
 
 		/**


### PR DESCRIPTION
Fix https://github.com/ranjithrd/lithium/issues/1

Skip secondary `help` commands on `import`